### PR TITLE
src/misc.c: Add missing #include directives

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -21,6 +21,7 @@
 #include <unistd.h> /* X_OK */
 #include <stdlib.h>
 #include <glib.h> 
+#include <glib/gstdio.h>
 #include "config.h"
 #include "misc.h"
 #include "main.h"
@@ -30,6 +31,7 @@
  * Run a shell command, with arguments.
  * Return TRUE on error.
  */
+#include <stdio.h>
 #include <stdlib.h>    /* exit() */
 #include <unistd.h>    /* fork() */
 #include <sys/types.h> /* Used by fork() and stat() */


### PR DESCRIPTION
They are required to avoid implicit function declarations for g_access and perror.  This change increases compatibility with strict C99 compilers.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC